### PR TITLE
Start using AssetRegistry 

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,4 +6,3 @@ Vue
 DataStructures
 Colors
 Observables
-AssetRegistry

--- a/REQUIRE
+++ b/REQUIRE
@@ -6,3 +6,4 @@ Vue
 DataStructures
 Colors
 Observables
+AssetRegistry

--- a/src/InteractBulma.jl
+++ b/src/InteractBulma.jl
@@ -2,7 +2,6 @@ __precompile__()
 
 module InteractBulma
 
-using AssetRegistry
 using Reexport
 @reexport using InteractBase
 using WebIO, Vue, DataStructures, CSSUtil
@@ -41,14 +40,14 @@ const all_js = joinpath(Pkg.dir("InteractBase"), "assets", "all.js")
 
 function InteractBase.libraries(::Bulma)
     bulmalibs = InteractBase.isijulia() ?
-        [AssetRegistry.register(main_css)] :
+        [main_css] :
         [
-            AssetRegistry.register(bulma_min_css),
-            AssetRegistry.register(bulma_slider_min_css),
-            AssetRegistry.register(bulma_switch_min_css),
-            AssetRegistry.register(bulma_checkradio_min_css),
+            bulma_min_css,
+            bulma_slider_min_css,
+            bulma_switch_min_css,
+            bulma_checkradio_min_css,
         ]
-    vcat(AssetRegistry.register(all_js), bulmalibs)
+    vcat(all_js, bulmalibs)
 end
 
 function __init__()

--- a/src/InteractBulma.jl
+++ b/src/InteractBulma.jl
@@ -37,6 +37,7 @@ const bulma_min_css = joinpath(@__DIR__, "..", "assets", "bulma.min.css")
 const bulma_slider_min_css = joinpath(@__DIR__, "..", "assets", "bulma-slider.min.css")
 const bulma_switch_min_css = joinpath(@__DIR__, "..", "assets", "bulma-switch.min.css")
 const bulma_checkradio_min_css = joinpath(@__DIR__, "..", "assets", "bulma-checkradio.min.css")
+const all_js = joinpath(Pkg.dir("InteractBase"), "assets", "all.js")
 
 function InteractBase.libraries(::Bulma)
     bulmalibs = InteractBase.isijulia() ?
@@ -47,7 +48,7 @@ function InteractBase.libraries(::Bulma)
             AssetRegistry.register(bulma_switch_min_css),
             AssetRegistry.register(bulma_checkradio_min_css),
         ]
-    vcat("/pkg/InteractBase/all.js", bulmalibs)
+    vcat(AssetRegistry.register(all_js), bulmalibs)
 end
 
 function __init__()

--- a/src/InteractBulma.jl
+++ b/src/InteractBulma.jl
@@ -2,6 +2,7 @@ __precompile__()
 
 module InteractBulma
 
+using AssetRegistry
 using Reexport
 @reexport using InteractBase
 using WebIO, Vue, DataStructures, CSSUtil
@@ -31,14 +32,20 @@ export Bulma
 
 struct Bulma<:InteractBase.WidgetTheme; end
 
+const main_css = joinpath(@__DIR__, "..", "assets", "main.css")
+const bulma_min_css = joinpath(@__DIR__, "..", "assets", "bulma.min.css")
+const bulma_slider_min_css = joinpath(@__DIR__, "..", "assets", "bulma-slider.min.css")
+const bulma_switch_min_css = joinpath(@__DIR__, "..", "assets", "bulma-switch.min.css")
+const bulma_checkradio_min_css = joinpath(@__DIR__, "..", "assets", "bulma-checkradio.min.css")
+
 function InteractBase.libraries(::Bulma)
     bulmalibs = InteractBase.isijulia() ?
-        ["/pkg/InteractBulma/main.css"] :
+        [AssetRegistry.register(main_css)] :
         [
-            "/pkg/InteractBulma/bulma.min.css",
-            "/pkg/InteractBulma/bulma-slider.min.css",
-            "/pkg/InteractBulma/bulma-switch.min.css",
-            "/pkg/InteractBulma/bulma-checkradio.min.css",
+            AssetRegistry.register(bulma_min_css),
+            AssetRegistry.register(bulma_slider_min_css),
+            AssetRegistry.register(bulma_switch_min_css),
+            AssetRegistry.register(bulma_checkradio_min_css),
         ]
     vcat("/pkg/InteractBase/all.js", bulmalibs)
 end


### PR DESCRIPTION
Hi, 

I wanted to send this PR to use `AssetRegistry.jl`. This allows users to serve assets from arbitrary file and folder locations. 

The css file locations are specified as `consts` because this would facilitate static compilation and shipping. 

cc: @shashi